### PR TITLE
Fix Unhandled Runtime Error (reading 'loadScript' of undefined)

### DIFF
--- a/src/useRutterLink.ts
+++ b/src/useRutterLink.ts
@@ -43,7 +43,7 @@ export const useRutterLink = (options: RutterLinkOptions) => {
     }
 
     // do the rutter loader side effect
-    (window as any).RutterLoader.loadScript(() => {
+    (window as any).RutterLoader && (window as any).RutterLoader.loadScript(() => {
       setRutterLoaderLoaded(true);
     });
 


### PR DESCRIPTION
When we try using `react-rutter-link` hook multiple times on the same page we got the `Unhandled Runtime Error`. Checking loading state is not enough, so in case `window.RutterLoader` is undefined just skip loadScript call.

![Screenshot 2021-08-02 at 4 25 43 PM](https://user-images.githubusercontent.com/79540316/127869075-b5e683e9-16f6-4fa2-95d6-d3a678255d9c.png)
